### PR TITLE
prevent clean filter extraction before cycle end

### DIFF
--- a/prototypes/Buildings.lua
+++ b/prototypes/Buildings.lua
@@ -720,6 +720,7 @@ function buildings.enable()
         airFilter.next_upgrade = nil
         airFilter.energy_usage = "1200KW"
         airFilter.energy_source.drain = "50KW"
+        airFilter.return_ingredients_on_change = false
         airFilter.match_speed_to_activity = true
         airFilter.match_volume_to_activity = true
         airFilter.crafting_speed = 1
@@ -1142,9 +1143,9 @@ function buildings.enable()
         recipePollution2.category = "air-filter-rampant-industry"
         recipePollution2.subgroup = "raw-material"
         recipePollution2.normal.ingredients = {
-            {name="clean-air-filter-rampant-industry", amount=6}
+            {name="clean-air-filter-rampant-industry", amount=2}
         }
-        recipePollution2.normal.energy_required = 90
+        recipePollution2.normal.energy_required = 30
         recipePollution2.normal.hide_from_player_crafting = true
         recipePollution2.normal.hidden = false
         recipePollution2.normal.enabled = true
@@ -1154,7 +1155,7 @@ function buildings.enable()
         recipePollution2.normal.show_amount_in_title = false
         recipePollution2.normal.result = nil
         recipePollution2.normal.results = {
-            {name="dirty-air-filter-rampant-industry", amount=6}
+            {name="dirty-air-filter-rampant-industry", amount=2}
         }
 
         local recipeAirFilter = table.deepcopy(data.raw["recipe"]["assembling-machine-2"])


### PR DESCRIPTION
fix: Player could mine airfilter building at the end of cycle and recieve clean filters after they have been used.
Also made advanced air filter recipe more granular to avoid big losses of filters, because with my previous idea implemented and building activity disabled on low polllution it's an additional work for player to create some pollution in chunk to allow air filter to finish recipe cycle and not loose filter component. 

Unfortunately Factorio engine doesn't support extraction of finished product from assembler on early deconstruction via any flags.